### PR TITLE
Homepage Error when user has less than 5 awards

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -656,7 +656,7 @@ app.get("/user/top5employess", function(req, res) {
           console.log(err);
           res.send("Error getting awardGiven");
         } else {
-          if(Object.keys(data).length === 0)
+          if(Object.keys(data).length < 5)
           {
             data = {
               employee1: "N/A",


### PR DESCRIPTION
Fixed issue when user had 5 awards or less the bar chart will cause an error. The bar chart updates after 5 awards are created under the user logged in.