### PR TITLE
Fix issue #39

### DIFF
--- a/client/src/components/admin/userAdministration.js
+++ b/client/src/components/admin/userAdministration.js
@@ -120,7 +120,6 @@ class AdminConsole extends Component {
     this.setState({
       editId: id,
       editEmail: editUser.email,
-      editPassword: editUser.password,
       editFirstName: editUser.firstName,
       editLastName: editUser.lastName,
       editUserClass: editUser.userClass,

--- a/server/server.js
+++ b/server/server.js
@@ -443,7 +443,7 @@ app.post("/admin/editUser", function(req, res) {
       }
     });
   }
-  if (req.body.password != "") {
+  if (req.body.password && req.body.password != "") {
     bcrypt.genSalt(10, function(err, salt) {
       bcrypt.hash(req.body.password, salt, function(err, hash) {
         changes.password = hash;


### PR DESCRIPTION
Opening the edit user modal, the editPassword field was being populated with the user's password. However, we removed the password being returned from the server, but did not remove the relevant state update in the react component.