### PR TITLE
Fix edit password bug

### DIFF
--- a/client/src/components/admin/userAdministration.js
+++ b/client/src/components/admin/userAdministration.js
@@ -122,6 +122,7 @@ class AdminConsole extends Component {
       editEmail: editUser.email,
       editFirstName: editUser.firstName,
       editLastName: editUser.lastName,
+      editPassword: "",
       editUserClass: editUser.userClass,
       editModalOpen: true
     });


### PR DESCRIPTION
Leaving this blank made the modal open with the previously entered password if another user had already been edited